### PR TITLE
V6.6

### DIFF
--- a/TarsierSpaceTechnology/TarsierSpaceTech/Distribution/GameData/TarsierSpaceTech/Changelog.txt
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/Distribution/GameData/TarsierSpaceTech/Changelog.txt
@@ -1,4 +1,5 @@
-﻿V6.6 "ResearchBodies 1.9 & Bug Fixes"
+﻿V6.6 "KSP 1.2.1 & ResearchBodies 1.9"
+	Re-compile for KSP 1.2.1.
 	Moved initializers out of ..ctor to avoid Unity messages.
 	Eliminate NullRef errors on scene change for onGUI (was issuing two errors each time you switched scene).
 	Support ResearchBodies 1.9.

--- a/TarsierSpaceTechnology/TarsierSpaceTech/Distribution/GameData/TarsierSpaceTech/Changelog.txt
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/Distribution/GameData/TarsierSpaceTech/Changelog.txt
@@ -1,4 +1,8 @@
-﻿V6.5 "KSP 1.2"
+﻿V6.6 "ResearchBodies 1.9 & Bug Fixes"
+	Moved initializers out of ..ctor to avoid Unity messages.
+	Eliminate NullRef errors on scene change for onGUI (was issuing two errors each time you switched scene).
+	Support ResearchBodies 1.9.
+V6.5 "KSP 1.2"
 	Changes for KSP 1.2.
 	Added a check to Contract generation to ensure the TST parts are actually loaded in-game (removes log spam if they aren't).
 	Moved Some (*not all) settings to the new Stock Difficulty Settings Integration.

--- a/TarsierSpaceTechnology/TarsierSpaceTech/Distribution/GameData/TarsierSpaceTech/TarsierSpaceTechnology.version
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/Distribution/GameData/TarsierSpaceTech/TarsierSpaceTechnology.version
@@ -2,8 +2,8 @@
 "NAME":"TarsierSpaceTechnology",
 "URL":"http://ksp-avc.cybutek.net/version.php?id=148",
 "DOWNLOAD":"http://spacedock.info/mod/143/Tarsier%20Space%20Technology%20with%20Galaxies%20Continued...",
-"VERSION":{"MAJOR":6,"MINOR":5,"PATCH":0,"BUILD":0},
-"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":0},
+"VERSION":{"MAJOR":6,"MINOR":6,"PATCH":0,"BUILD":0},
+"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":1},
 "KSP_VERSION_MIN":{"MAJOR":1,"MINOR":2,"PATCH":0},
-"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":2,"PATCH":0}
+"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":2,"PATCH":1}
 }

--- a/TarsierSpaceTechnology/TarsierSpaceTech/Properties/AssemblyInfo.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.5")]
-[assembly: KSPAssembly("TarsierSpaceTech", 6, 5)]
+[assembly: AssemblyVersion("6.6")]
+[assembly: KSPAssembly("TarsierSpaceTech", 6, 6)]
 

--- a/TarsierSpaceTechnology/TarsierSpaceTech/RBWrapper.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/RBWrapper.cs
@@ -216,7 +216,7 @@ namespace TarsierSpaceTech
                 //Methods
 
                 LogFormatted_DebugOnly("Getting enabled Method");
-                enabledMethod = RBAPIType.GetMethod("get_enabled", BindingFlags.Public | BindingFlags.Static);
+                enabledMethod = RBAPIType.GetMethod("get_Enabled", BindingFlags.Public | BindingFlags.Static);
                 LogFormatted_DebugOnly("Success: " + (enabledMethod != null));
 
                 LogFormatted_DebugOnly("Getting FoundBody Method");

--- a/TarsierSpaceTechnology/TarsierSpaceTech/TSTChemCam.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/TSTChemCam.cs
@@ -61,9 +61,9 @@ namespace TarsierSpaceTech
 		private int frameLimit = 5;
 		private int f;
 		
-		private List<ScienceData> _scienceData = new List<ScienceData>();
+		private List<ScienceData> _scienceData;
 
-		private static Texture2D viewfinder = new Texture2D(1, 1);
+		private static Texture2D viewfinder;
 
 		private static List<string> PlanetNames;
 
@@ -90,8 +90,9 @@ namespace TarsierSpaceTech
 				_inEditor = true;
 				return;
 			}
-
-			Utilities.Log_Debug("Starting ChemCam");
+            viewfinder = new Texture2D(1, 1);
+            _scienceData = new List<ScienceData>();
+            Utilities.Log_Debug("Starting ChemCam");
 			_lookTransform = Utilities.FindChildRecursive(transform,"CameraTransform");
 			_camera=_lookTransform.gameObject.AddComponent<TSTCameraModule>();
 
@@ -192,7 +193,8 @@ namespace TarsierSpaceTech
 
 		public void OnGUI()
 		{
-			if (!_inEditor && _camera.Enabled && vessel.isActiveVessel && FlightUIModeController.Instance.Mode != FlightUIMode.ORBITAL && !Utilities.isPauseMenuOpen)
+            if (Time.timeSinceLevelLoad < 2f) return;
+            if (!_inEditor && _camera.Enabled && vessel.isActiveVessel && FlightUIModeController.Instance.Mode != FlightUIMode.ORBITAL && !Utilities.isPauseMenuOpen)
 			{
 				if (!Textures.StylesSet) Textures.SetupStyles();
 

--- a/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
@@ -914,9 +914,10 @@ namespace TarsierSpaceTech
 
         public void OnGUI()
         {
+            if (Time.timeSinceLevelLoad < 2f) return;
             if (Utilities.GameModeisFlight)
             {
-                if (!_inEditor && _camera != null)
+                if (!_inEditor && _camera != null && !Utilities.isPauseMenuOpen)
                 {
                     if (!Textures.StylesSet) Textures.SetupStyles();
 


### PR DESCRIPTION
V6.6 "KSP 1.2.1 & ResearchBodies 1.9"
	Re-compile for KSP 1.2.1.
	Moved initializers out of ..ctor to avoid Unity messages.
	Eliminate NullRef errors on scene change for onGUI (was issuing two errors each time you switched scene).
	Support ResearchBodies 1.9.