### PR TITLE
Fix CB and Galaxy target list in Telescopes UI, also will update in flight

### DIFF
--- a/TarsierSpaceTechnology/TarsierSpaceTech/Distribution/GameData/TarsierSpaceTech/Changelog.txt
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/Distribution/GameData/TarsierSpaceTech/Changelog.txt
@@ -1,4 +1,7 @@
-﻿V6.9
+﻿V7.0
+	Fix List of Celestial Bodies display for targeting in the Telescopes UI.
+	Also the same Celestial Body list will update while in flight if the player is using a Contracts app that accepts a contract for a Celestial Body.
+V6.9
 	Fix ChemCam not finding the ground/celestial body.
 	Also allow ChemCam and Telescopes to be opened and closed in VAB/SPH to allow user to check part placement when camera is open.
 V6.8

--- a/TarsierSpaceTechnology/TarsierSpaceTech/Properties/AssemblyInfo.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.9.0")]
-[assembly: KSPAssembly("TarsierSpaceTech", 6, 9)]
+[assembly: AssemblyVersion("7.0.0")]
+[assembly: KSPAssembly("TarsierSpaceTech", 7, 0)]
 

--- a/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
+++ b/TarsierSpaceTechnology/TarsierSpaceTech/TSTSpaceTelescope.cs
@@ -280,6 +280,7 @@ namespace TarsierSpaceTech
             GameEvents.onVesselDestroy.Add(removeFlightInputHandler);
             GameEvents.OnVesselRecoveryRequested.Add(removeFlightInputHandler);
             GameEvents.Contract.onContractsLoaded.Add(onContractSystemReady);
+            GameEvents.Contract.onAccepted.Add(onContractAccepted);
             Utilities.Log_Debug("TSTTel Added Input Callback");
             //if (Active) //Moved to OnUpdate so we can process any override/disable event parameters correctly.
             //    StartCoroutine(openCamera());
@@ -291,6 +292,7 @@ namespace TarsierSpaceTech
             GameEvents.onVesselDestroy.Remove(removeFlightInputHandler);
             GameEvents.OnVesselRecoveryRequested.Remove(removeFlightInputHandler);
             GameEvents.Contract.onContractsLoaded.Remove(onContractSystemReady);
+            GameEvents.Contract.onAccepted.Remove(onContractAccepted);
         }
 
         private void buildTargetLists()
@@ -323,6 +325,12 @@ namespace TarsierSpaceTech
                     contractTargets.Add(TSTtelescopecontracts[i].target.name);
                 }
             }
+        }
+
+        protected void onContractAccepted(Contracts.Contract contract)
+        {
+            contractTargets.Clear();
+            onContractSystemReady();
         }
 
         private IEnumerator setSASParams()
@@ -944,13 +952,13 @@ namespace TarsierSpaceTech
             int newTarget = -1;
             for (int i = 0; i < cbTargetList.Count; i++)
             {
-                //If Not Progress completed on this body skip it. (Always not true if Contracts system is not active).
-                if (!TSTProgressTracker.HasTelescopeCompleted(cbTargetList[i]) && !contractTargets.Contains(cbTargetList[i].name))
+                //If Career Game and Not Progress completed on this body skip it. 
+                if (!TSTProgressTracker.HasTelescopeCompleted(cbTargetList[i]) && HighLogic.CurrentGame.Mode == Game.Modes.CAREER)
                 {
                     continue;
                 }
-                //If we are filtering the list to only contract targets and this body is not in the list skip it.
-                if (filterContractTargets && !contractTargets.Contains(cbTargetList[i].name))
+                //If we are filtering the list to only contract targets and this body is not in the list skip it (career game only).
+                if (HighLogic.CurrentGame.Mode == Game.Modes.CAREER && filterContractTargets && !contractTargets.Contains(cbTargetList[i].name))
                 {
                     continue;
                 }
@@ -1018,16 +1026,16 @@ namespace TarsierSpaceTech
             int newTarget = -1;
             for (int i = 0; i < galaxyTargetList.Count; i++)
             {
-                //If Not Progress completed on this body skip it. (Always not true if Contracts system is not active).
-                if (!TSTProgressTracker.HasTelescopeCompleted(galaxyTargetList[i]) && !contractTargets.Contains(galaxyTargetList[i].name))
+                //If Career Game and Not Progress completed on this body skip it. 
+                if (!TSTProgressTracker.HasTelescopeCompleted(galaxyTargetList[i]) && HighLogic.CurrentGame.Mode == Game.Modes.CAREER)
                 {
                     continue;
                 }
-                //If we are filtering the list to only contract targets and this body is not in the list skip it.
-                if (filterContractTargets && !contractTargets.Contains(galaxyTargetList[i].name))
+                //If we are filtering the list to only contract targets and this body is not in the list skip it (career game only).
+                if (HighLogic.CurrentGame.Mode == Game.Modes.CAREER && filterContractTargets && !contractTargets.Contains(galaxyTargetList[i].name))
                 {
                     continue;
-                }
+                }                
                 //If ResearchBodies is installed and enabled, check if body is researched, if not skip it.
                 if (TSTMstStgs.Instance.isRBloaded && RBWrapper.RBactualAPI.enabled)
                 {


### PR DESCRIPTION
Fix List of Celestial Bodies display for targeting in the Telescopes UI.   
Also the same Celestial Body list will update while in flight if the player is using a Contracts app that accepts a contract for a Celestial Body.